### PR TITLE
Ajout de la page MonsterList

### DIFF
--- a/src/components/organisms/MonsterList.tsx
+++ b/src/components/organisms/MonsterList.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { usePokemons } from "@/hooks/usePokemon.ts";
+import PokemonCard from "../molecules/PokemonCard";
+import Button from "../atoms/Button";
+import Text from "../atoms/Text";
+import { useTranslation } from "react-i18next";
+
+const MonsterList: React.FC = () => {
+    const { pokemons, loading, error, loadMore, hasMore } = usePokemons({ limit: 12 });
+    const { t } = useTranslation();
+
+    if (loading && pokemons.length === 0) {
+        return <Text>Chargement des Pokémon...</Text>;
+    }
+
+    if (error) {
+        return <Text color="danger">{error.message}</Text>;
+    }
+
+    return (
+        <div className="flex flex-col gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+                {pokemons.map((pokemon) => (
+                    <PokemonCard
+                        key={pokemon.id}
+                        {...{
+                            name: pokemon.name,
+                            image: pokemon.image,
+                            types: pokemon.types,
+                            stats: {
+                                hp: pokemon.stats.hp,
+                                attack: pokemon.stats.attack,
+                                defense: pokemon.stats.defense,
+                                speed: pokemon.stats.speed,
+                            },
+                        }}
+                    />
+                ))}
+            </div>
+
+            {hasMore && (
+                <div className="flex justify-center mt-6">
+                    <Button onClick={loadMore}>{t("actions.loadMore")}</Button>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default MonsterList;

--- a/src/hooks/usePokemon.ts
+++ b/src/hooks/usePokemon.ts
@@ -46,9 +46,9 @@ export const usePokemons = ({
 
   useEffect(() => {
     if (initialLoad) {
-      loadPokemons(offset);
+      loadPokemons(0); // Appelle l’offset 0 au tout début
     }
-  }, [initialLoad, loadPokemons, offset]);
+  }, []);
 
   const loadMore = useCallback(() => {
     if (!loading && hasMore) {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -5,8 +5,12 @@
     "search": "Search...",
     "passwordError": "Password too short"
   },
+  "actions": {
+    "loadMore": "Load more"
+  },
   "titles": {
-    "welcome": "Welcome to PokeApp"
+    "welcome": "Welcome to PokeApp",
+    "allPokemon": "All Pokémon List"
   },
   "descriptions": {
     "home": "Catch them all with a quick search!"

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -5,8 +5,12 @@
     "search": "Rechercher...",
     "passwordError": "Mot de passe trop court"
   },
+  "actions": {
+    "loadMore": "Charger plus"
+  },
   "titles": {
-    "welcome": "Bienvenue sur PokeApp"
+    "welcome": "Bienvenue sur PokeApp",
+    "allPokemon": "Liste de tous les Pokémon"
   },
   "descriptions": {
     "home": "Attrapez-les tous avec une recherche rapide !"

--- a/src/pages/MonsterListPage.tsx
+++ b/src/pages/MonsterListPage.tsx
@@ -1,0 +1,22 @@
+// src/pages/MonsterListPage.tsx
+
+import React from "react";
+import MonsterList from "../components/organisms/MonsterList";
+import Text from "../components/atoms/Text";
+import { useTranslation } from "react-i18next";
+
+const MonsterListPage: React.FC = () => {
+    const { t } = useTranslation();
+
+    return (
+        <div className="p-6">
+            <Text variant="h1" size="2xl" className="text-center text-blue-400 mb-6">
+                {t("titles.allPokemon") || "Tous les Pokémon"}
+            </Text>
+
+            <MonsterList />
+        </div>
+    );
+};
+
+export default MonsterListPage;

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,12 +1,13 @@
 import { Routes, Route } from "react-router-dom";
 import HomePage from "../pages/HomePage";
+import MonsterListPage from "@/pages/MonsterListPage.tsx";
 
 
 const AppRoutes = () => {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
-      <Route path="/pokemons" element={<HomePage />} />
+      <Route path="/pokemons" element={<MonsterListPage />} />
       <Route path="/pokemons/:id" element={<HomePage />} />
       {/* //<Route path="*" element={<NotFoundPage />} /> */}
     </Routes>


### PR DESCRIPTION
Cette PR ajoute la page MonsterListPage qui affiche une liste paginée de Pokémon.

Contenu :
	•	Nouvelle page accessible via /pokemons
	•	Composant MonsterList pour afficher les Pokémon sous forme de cartes
	•	Chargement de 12 Pokémon à la fois, avec bouton “Charger plus”
	•	Gestion des états de chargement et d’erreur
	•	Traductions ajoutées pour le titre et le bouton (fr.json / en.json)
	•	Correction dans le hook usePokemons : le useEffect initial ne relance plus les chargements automatiquement à chaque changement d’offset, ce qui évite d’écraser la liste après un “Charger plus”. Maintenant, le premier chargement se fait une seule fois au montage.